### PR TITLE
q --> epsilon(k+q)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dispersions"
 uuid = "9451dd48-6b2a-4bde-a443-9ec270a37806"
 authors = ["Julian Stobbe <Atomtomate@gmx.de>", "Jan Frederik Weissler <f.weissler@outlook.de>", "<Marvin Leusch <marvin.leusch@studium.uni-hamburg.de>"]
-version = "0.8.11"
+version = "0.8.12"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dispersions"
 uuid = "9451dd48-6b2a-4bde-a443-9ec270a37806"
 authors = ["Julian Stobbe <Atomtomate@gmx.de>", "Jan Frederik Weissler <f.weissler@outlook.de>", "<Marvin Leusch <marvin.leusch@studium.uni-hamburg.de>"]
-version = "0.8.12"
+version = "0.8.13"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Dispersions"
 uuid = "9451dd48-6b2a-4bde-a443-9ec270a37806"
 authors = ["Julian Stobbe <Atomtomate@gmx.de>", "Jan Frederik Weissler <f.weissler@outlook.de>", "<Marvin Leusch <marvin.leusch@studium.uni-hamburg.de>"]
-version = "0.8.10"
+version = "0.8.11"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/Dispersions.jl
+++ b/src/Dispersions.jl
@@ -11,7 +11,7 @@ using EquivalenceClassesConstructor
 export KGrid
 
 # access functions
-export gridPoints, Nk, gridshape, dispersion, grid_type, grid_dimension, ϵ_k_plus_q
+export gridPoints, Nk, gridshape, dispersion, grid_type, grid_dimension, grid_dimension, ϵ_k_plus_q
 
 # grid functions
 export reduceKArr,reduceKArr!,expandKArr,expandKArr!,

--- a/src/Dispersions.jl
+++ b/src/Dispersions.jl
@@ -11,7 +11,7 @@ using EquivalenceClassesConstructor
 export KGrid
 
 # access functions
-export gridPoints, Nk, gridshape, dispersion, grid_type, grid_dimension, gen_shifted_ϵkGrid
+export gridPoints, Nk, gridshape, dispersion, grid_type, grid_dimension, ϵ_k_plus_q
 
 # grid functions
 export reduceKArr,reduceKArr!,expandKArr,expandKArr!,

--- a/src/Dispersions.jl
+++ b/src/Dispersions.jl
@@ -11,7 +11,7 @@ using EquivalenceClassesConstructor
 export KGrid
 
 # access functions
-export gridPoints, Nk, gridshape, dispersion, grid_type
+export gridPoints, Nk, gridshape, dispersion, grid_type, grid_dimension, gen_shifted_ϵkGrid
 
 # grid functions
 export reduceKArr,reduceKArr!,expandKArr,expandKArr!,

--- a/src/KGrid.jl
+++ b/src/KGrid.jl
@@ -1,4 +1,5 @@
 #TODO: t/tp/tpp should be a vector
+# TODO: rename gen_shifted_ϵkGrid to something appropriate
 
 """
     KGrid{T <: KGridType, D}
@@ -104,16 +105,32 @@ function gen_kGrid(kg::String, Ns::Int)
     end
 end
 
-function gen_shifted_ϵkGrid(kg::KGrid,shift::NTuple)  
-    D = length(kg.kGrid[1])
-    if D != length(shift)
+"""
+    gen_shifted_ϵkGrid(kg::KGrid, q::NTuple)
+    
+    Evaluates the dispersion relation on the given grid but shifted by a constant vector `q` in reciprocal space.
+
+    Returns:
+    -------------
+    ϵ(k+shift): `Vector{NTuple{D,Float64}}`, where D is the diemenion of the grid. Dispersion relation evaluated on the given grid but shifted by the the vector q.
+
+    ATTENTION: So far this function is tested for the simple cubic lattice only!
+    
+    Arguments:
+    -------------
+    - `kG`       : reciprocal lattice
+    - **`q`**    : vector in reciprocal space
+"""
+function gen_shifted_ϵkGrid(kG::KGrid, q::NTuple)  
+    D = grid_dimension(kG)
+    if D != length(q)
         throw(ArgumentError("Grid dimension differs from shift dimension!"))
     else
-        shifted_kgrid = Vector{NTuple{D,Float64}}(undef,length(kg.kGrid))
-        for (i,k) in enumerate(kg.kGrid)
-            shifted_kgrid[i] = k .+ shift
+        k_plus_q = Vector{NTuple{D,Float64}}(undef,length(kG.kGrid))
+        for (i,k) in enumerate(kG.kGrid)
+            k_plus_q[i] = k .+ q
         end
-        return kg.gen_ϵkGrid(shifted_kgrid,kg.t)
+        return gen_ϵkGrid(grid_type(kG), k_plus_q, kG.t)
     end
 end
 
@@ -121,7 +138,24 @@ end
     grid_type(kG::KGrid)
 
     Maps the given grid onto its KGridType without the number of dimensions.
+
+    Returns:
+    -------------
+    type : `KGridType`, type of the reciprocal lattice space, e.g. `cP`.
 """
 function grid_type(kG::KGrid)
     return typeof(kG).parameters[1]
+end
+
+"""
+    grid_dimension(kG::KGrid)
+
+    Maps the given grid onto its dimension.
+
+    Returns:
+    -------------
+    D : `Int`, dimension of the reciprocal lattice space.
+"""
+function grid_dimension(kG::KGrid)
+    return typeof(kG).parameters[2]
 end

--- a/src/KGrid.jl
+++ b/src/KGrid.jl
@@ -106,9 +106,9 @@ function gen_kGrid(kg::String, Ns::Int)
 end
 
 """
-    gen_shifted_ϵkGrid(kg::KGrid, q::NTuple)
+    ϵ_k_plus_q(kG::KGrid, q::NTuple)
     
-    Evaluates the dispersion relation on the given grid but shifted by a constant vector `q` in reciprocal space.
+    Evaluates the dispersion relation on the given reciprocal space but expanded and shifted by a constant vector `q`. The corresponding points in reciprocal space are given by `expandKArr(kG, gridPoints(kG))`.
 
     Returns:
     -------------
@@ -121,15 +121,12 @@ end
     - `kG`       : reciprocal lattice
     - **`q`**    : vector in reciprocal space
 """
-function gen_shifted_ϵkGrid(kG::KGrid, q::NTuple)  
-    D = grid_dimension(kG)
-    if D != length(q)
+function ϵ_k_plus_q(kG::KGrid, q::NTuple)
+    if grid_dimension(kG) != length(q)
         throw(ArgumentError("Grid dimension differs from shift dimension!"))
     else
-        k_plus_q = Vector{NTuple{D,Float64}}(undef,length(kG.kGrid))
-        for (i,k) in enumerate(kG.kGrid)
-            k_plus_q[i] = k .+ q
-        end
+        k_sampling_full  = expandKArr(kG, gridPoints(kG))[:]
+        k_plus_q = map(k -> k_sampling_full[k] .+ q, 1:length(k_sampling_full))
         return gen_ϵkGrid(grid_type(kG), k_plus_q, kG.t)
     end
 end

--- a/test/KGrid.jl
+++ b/test/KGrid.jl
@@ -1,6 +1,6 @@
 using Base.Iterators
 # TODO: test kvices/ifft
-# TODO: test gen_shifted_ϵkGrid for other grid types than simple cubic
+# TODO: test ϵ_k_plus_q for other grid types than simple cubic
 
 @testset "gen_kGrid" begin
     @test false skip = true
@@ -21,35 +21,35 @@ end
     
     # ----- 3d simple cubic ----
     sc3d = gen_kGrid("3dsc-1.2",4)
-    ϵk = dispersion(sc3d)
+    ϵk = expandKArr(sc3d, dispersion(sc3d))[:]
     ϵk[abs.(ϵk) .< δ] .= zero(eltype(ϵk))
     
-    ϵkq = gen_shifted_ϵkGrid(sc3d, (0.0,0.0,0.0))
+    ϵkq = ϵ_k_plus_q(sc3d, (0.0,0.0,0.0))
     ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
     @test all(ϵk .≈ ϵkq)
     
-    ϵkq = gen_shifted_ϵkGrid(sc3d, (π, π, π))
+    ϵkq = ϵ_k_plus_q(sc3d, (π, π, π))
     ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
     @test all(ϵk .≈ -ϵkq)
     
-    ϵkq = gen_shifted_ϵkGrid(sc3d, (2*π,2*π,2*π))
+    ϵkq = ϵ_k_plus_q(sc3d, (2*π,2*π,2*π))
     ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
     @test all(ϵk .≈ ϵkq)
 
     # ----- 2d simple cubic ----
     sc2d = gen_kGrid("2dsc-1.2",4)
-    ϵk = dispersion(sc2d)
+    ϵk = expandKArr(sc2d, dispersion(sc2d))[:]
     ϵk[abs.(ϵk) .< δ] .= zero(eltype(ϵk))
     
-    ϵkq = gen_shifted_ϵkGrid(sc2d, (0.0,0.0))
+    ϵkq = ϵ_k_plus_q(sc2d, (0.0,0.0))
     ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
     @test all(ϵk .≈ ϵkq)
 
-    ϵkq = gen_shifted_ϵkGrid(sc2d, (π, π))
+    ϵkq = ϵ_k_plus_q(sc2d, (π, π))
     ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
     @test all(ϵk .≈ -ϵkq)
     
-    ϵkq = gen_shifted_ϵkGrid(sc2d, (2*π,2*π))
+    ϵkq = ϵ_k_plus_q(sc2d, (2*π,2*π))
     ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
     @test all(ϵk .≈ ϵkq)
 

--- a/test/KGrid.jl
+++ b/test/KGrid.jl
@@ -54,3 +54,35 @@ end
     @test all(ϵk .≈ ϵkq)
 
 end
+
+@testset "grid properties" begin
+    # cF
+    fcc = gen_kGrid("fcc-1.2",2)
+    @test grid_dimension(fcc) == 3
+    @test grid_type(fcc) === cF
+    
+    # cI
+    bcc = gen_kGrid("bcc-1.2",2)
+    @test grid_dimension(bcc) == 3
+    @test grid_type(bcc) === cI
+
+    # cP
+    sc2d = gen_kGrid("2Dsc-1.3",2)
+    @test grid_dimension(sc2d) == 2
+    @test grid_type(sc2d) === cP
+    
+    sc3d = gen_kGrid("3Dsc-1.3",2)
+    @test grid_type(sc3d) === cP
+    @test grid_dimension(sc3d) == 3
+
+    # cPnn
+    sc2dnn = gen_kGrid("2Dsc-1.3--1.4-1.5",2)
+    @test grid_dimension(sc2dnn) == 2
+    @test grid_type(sc2dnn) === cPnn
+
+    # hexagonal
+    hexa = gen_kGrid("p6m-1.3", 2)
+    @test grid_type(hexa) === p6m
+    @test grid_dimension(hexa) == 2
+    
+end

--- a/test/KGrid.jl
+++ b/test/KGrid.jl
@@ -3,17 +3,17 @@ using Base.Iterators
 # TODO: test ϵ_k_plus_q for other grid types than simple cubic
 
 @testset "gen_kGrid" begin
-    @test false skip = true
-    # gl = map(x -> gen_kGrid(x, NN), grid_list)
-    # for i = 1:length(gl)
-    #     for NN in [4, 6, 8]
-    #         kG = gl[i]
-    #         Di = grid_list_D[i]
-    #         @test kG.Nk == NN^Di
-    #         @test kG.Ns == NN
-    #         @test all(size(kG.fft_cache) .== repeat([NN], Di))
-    #     end
-    # end
+    for NN in [4, 6, 8]
+        gl = map(x -> gen_kGrid(x, NN), grid_list)
+        for i = 1:length(gl)
+            kG = gl[i]
+            Di = grid_list_D[i]
+            @test kG.Nk == NN^Di
+            @test kG.Ns == NN
+            @test all(size(kG.cache1) .== repeat([NN], Di))
+            @test all(size(kG.cache2) .== repeat([NN], Di))
+        end
+    end
 end
 
 @testset "shifted grid" begin

--- a/test/KGrid.jl
+++ b/test/KGrid.jl
@@ -1,15 +1,56 @@
 using Base.Iterators
-#TODO: test kvices/ifft
+# TODO: test kvices/ifft
+# TODO: test gen_shifted_ϵkGrid for other grid types than simple cubic
 
 @testset "gen_kGrid" begin
-    gl = map(x -> gen_kGrid(x, NN), grid_list)
-    for i = 1:length(gl)
-        for NN in [4, 6, 8]
-            kG = gl[i]
-            Di = grid_list_D[i]
-            @test kG.Nk == NN^Di
-            @test kG.Ns == NN
-            @test all(size(kG.fft_cache) .== repeat([NN], Di))
-        end
-    end
+    @test false skip = true
+    # gl = map(x -> gen_kGrid(x, NN), grid_list)
+    # for i = 1:length(gl)
+    #     for NN in [4, 6, 8]
+    #         kG = gl[i]
+    #         Di = grid_list_D[i]
+    #         @test kG.Nk == NN^Di
+    #         @test kG.Ns == NN
+    #         @test all(size(kG.fft_cache) .== repeat([NN], Di))
+    #     end
+    # end
+end
+
+@testset "shifted grid" begin
+    δ = 10^(-8) # avoid comparison of small numbers
+    
+    # ----- 3d simple cubic ----
+    sc3d = gen_kGrid("3dsc-1.2",4)
+    ϵk = dispersion(sc3d)
+    ϵk[abs.(ϵk) .< δ] .= zero(eltype(ϵk))
+    
+    ϵkq = gen_shifted_ϵkGrid(sc3d, (0.0,0.0,0.0))
+    ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
+    @test all(ϵk .≈ ϵkq)
+    
+    ϵkq = gen_shifted_ϵkGrid(sc3d, (π, π, π))
+    ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
+    @test all(ϵk .≈ -ϵkq)
+    
+    ϵkq = gen_shifted_ϵkGrid(sc3d, (2*π,2*π,2*π))
+    ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
+    @test all(ϵk .≈ ϵkq)
+
+    # ----- 2d simple cubic ----
+    sc2d = gen_kGrid("2dsc-1.2",4)
+    ϵk = dispersion(sc2d)
+    ϵk[abs.(ϵk) .< δ] .= zero(eltype(ϵk))
+    
+    ϵkq = gen_shifted_ϵkGrid(sc2d, (0.0,0.0))
+    ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
+    @test all(ϵk .≈ ϵkq)
+
+    ϵkq = gen_shifted_ϵkGrid(sc2d, (π, π))
+    ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
+    @test all(ϵk .≈ -ϵkq)
+    
+    ϵkq = gen_shifted_ϵkGrid(sc2d, (2*π,2*π))
+    ϵkq[abs.(ϵkq) .< δ] .= zero(eltype(ϵkq))
+    @test all(ϵk .≈ ϵkq)
+
 end

--- a/test/cF.jl
+++ b/test/cF.jl
@@ -21,7 +21,6 @@ include("helper_functions.jl")
         @test all(comp_disp_ekgrid)=#
     end
 
-    @test grid_type(r8) === cF
     @test Nk(r8) == 2^3
     @test Nk(r64) == 4^3
     @test all(dispersion(r8) .≈ r8.ϵkGrid)

--- a/test/cI.jl
+++ b/test/cI.jl
@@ -8,7 +8,6 @@ include("helper_functions.jl")
     indTest = reduceKArr(r8, reshape([(1, 1, 1) (2, 1, 1) (1, 2, 1) (2, 2, 1) (1, 1, 2) (2, 1, 2) (1, 2, 2) (2, 2, 2)], (2,2,2)))
     gridTest = reduceKArr(r8, reshape([(0, 0, 0) (π, 0, π) (π, π, 0) (2π, π, π) (0, π, π) (π, π, 2π) (π, 2π, π) (2π, 2π, 2π)], (2,2,2)))
     
-    @test grid_type(r8) === cI
     @test Nk(r8) == 2^3
     @test Nk(r64) == 4^3
     @test all(dispersion(r8) .≈ r8.ϵkGrid)

--- a/test/cP.jl
+++ b/test/cP.jl
@@ -5,7 +5,6 @@ using Base.Iterators
     @test_throws ArgumentError gen_kGrid("2Dsc-1.3",3)
     r2 = gen_kGrid("2Dsc-1.3",2)
     r16 = gen_kGrid("2Dsc-1.4",16)
-    @test grid_type(r2) === cP
     @test Nk(r2) == 2^2
     @test all(dispersion(r2) .≈ r2.ϵkGrid)
     @test all(isapprox.(flatten(gridPoints(r2)), flatten([(0,0) (π,0) (π,π)])))
@@ -25,7 +24,6 @@ end
     r16 = gen_kGrid("3Dsc-1.1",4)
     indTest = reduceKArr(r2, reshape([(1, 1, 1) (2, 1, 1) (1, 2, 1) (2, 2, 1) (1, 1, 2) (2, 1, 2) (1, 2, 2) (2, 2, 2)], (2,2,2)))
     gridTest = reduceKArr(r2, reshape([(0, 0, 0) (π, 0, 0) (0, π, 0) (π, π, 0) (0, 0, π) (π, 0, π) (0, π, π) (π, π, π)], (2,2,2)))
-    @test grid_type(r2) === cP
     @test Nk(r2) == 2^3
     @test Nk(r16) == 4^3
     @test all(dispersion(r2) .≈ r2.ϵkGrid)

--- a/test/cPnn.jl
+++ b/test/cPnn.jl
@@ -4,7 +4,6 @@ using Base.Iterators
 @testset "2D" begin
     @test_throws ArgumentError gen_kGrid("2Dsc-1.3",3)
     r2 = gen_kGrid("2Dsc-1.3--1.4-1.5",2)
-    @test grid_type(r2) === cPnn
     @test r2.t ≈ 1.3
     @test r2.tp ≈ -1.4
     @test r2.tpp ≈ 1.5

--- a/test/hexagonal.jl
+++ b/test/hexagonal.jl
@@ -2,7 +2,6 @@
     r2 = gen_kGrid("p6m-1.3", 2)
     r3 = gen_kGrid("p6m-1.3", 4)
     r16 = gen_kGrid("p6m-1.4", 16)
-    @test grid_type(r2) === p6m
     @test_throws ArgumentError expandKArr(r16, [1, 2, 3, 4])
     #TODO: test gridpoints
     @test Nk(r2) == 2^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Dispersions
 using Random
 
 
+grid_list_D = [2, 3, 3, 2, 2, 2, 2, 2, 3]
 grid_list = ["2Dsc-1.3", "3Dsc-1.3", "fcc-1.4", "p6m-1.5", "p6m-1.5-1.7-0.0", "2Dsc--1.6", "2Dsc-1.7--1.8-1.9", "2Dsc-1.7--1.8--1.9", "bcc-1.1"]
 num_eps = 1e-8
 rng = MersenneTwister(0);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,10 @@ include("./helper_functions.jl")
     #include("./IO_SC.jl")    
 end
 
+@testset "KGrid" begin
+    include("./KGrid.jl")
+end
+
 @testset "cPnn" begin
     include("./cPnn.jl")
 end


### PR DESCRIPTION
Dispersion can now be evaluated on the shifted sampled reciprocal space. The result is returned in the unfolded form. This feature is useful when the dispersion within a formula is evaluated several times and at different points in the reciprocal space. Returning in unfolded form allows expressions to be calculated as a function of grid displacement without misunderstanding multiplicities.